### PR TITLE
ci: Configure Xcode Cloud API secrets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,34 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v4
+      - name: Add plist file
+        env:
+          AES256KEY: ${{ secrets.DAUPHIN_IOS_AES256KEY }}
+          AES256IV: ${{ secrets.DAUPHIN_IOS_AES256KIV }}
+        run: |
+          set -eu
+
+          : "${AES256KEY:?Set AES256KEY in the Xcode Cloud workflow environment}"
+          : "${AES256IV:?Set AES256IV in the Xcode Cloud workflow environment}"
+
+          script_directory="$GITHUB_WORKSPACE"
+          template_path="${script_directory}/app/dauphin/api.example.plist"
+          output_path="${script_directory}/app/dauphin/api.plist"
+          temporary_path="$(mktemp "${output_path}.XXXXXX")"
+
+          cleanup() {
+              rm -f "$temporary_path"
+          }
+          trap cleanup EXIT HUP INT TERM
+
+          cp "$template_path" "$temporary_path"
+          /usr/bin/plutil -replace AES.KEY -string "$AES256KEY" "$temporary_path"
+          /usr/bin/plutil -replace AES.IV -string "$AES256IV" "$temporary_path"
+          /usr/bin/plutil -lint "$temporary_path"
+          mv "$temporary_path" "$output_path"
+          trap - EXIT HUP INT TERM
+
+          echo "Generated dauphin/api.plist for the GitHub Actions workflow."
       - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
           distribution: 'zulu'
           java-version: 21
       - name: Set Xcode version
-        run: sudo xcode-select -s /Applications/Xcode_16.4.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
       - name: iOS debug build
         uses: nick-fields/retry@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
             -scheme "dauphin" \
             -testPlan Models \
             -configuration Debug \
-            -destination 'platform=iOS Simulator,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,name=iPhone 17' \
             -clonedSourcePackagesDirPath "${{ github.workspace }}/.spm" \
             -resultBundlePath TestResults.xcresult \
             test | xcbeautify --renderer github-actions --report junit --report-path reports/junit.xml
@@ -125,7 +125,7 @@ jobs:
           {
             echo "## test"
             echo "- Status: ${{ job.status }}"
-            echo "- Destination: iPhone 16"
+            echo "- Destination: iPhone 17"
             echo "- Result bundle: TestResults.xcresult"
             echo "- JUnit report: reports/junit.xml"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Add plist file
+        env:
+          AES256KEY: ${{ secrets.DAUPHIN_IOS_AES256KEY }}
+          AES256IV: ${{ secrets.DAUPHIN_IOS_AES256KIV }}
+        run: |
+          set -eu
+
+          : "${AES256KEY:?Set AES256KEY in the Xcode Cloud workflow environment}"
+          : "${AES256IV:?Set AES256IV in the Xcode Cloud workflow environment}"
+
+          script_directory="$GITHUB_WORKSPACE"
+          template_path="${script_directory}/app/dauphin/api.example.plist"
+          output_path="${script_directory}/app/dauphin/api.plist"
+          temporary_path="$(mktemp "${output_path}.XXXXXX")"
+
+          cleanup() {
+              rm -f "$temporary_path"
+          }
+          trap cleanup EXIT HUP INT TERM
+
+          cp "$template_path" "$temporary_path"
+          /usr/bin/plutil -replace AES.KEY -string "$AES256KEY" "$temporary_path"
+          /usr/bin/plutil -replace AES.IV -string "$AES256IV" "$temporary_path"
+          /usr/bin/plutil -lint "$temporary_path"
+          mv "$temporary_path" "$output_path"
+          trap - EXIT HUP INT TERM
+
+          echo "Generated dauphin/api.plist for the GitHub Actions workflow."
+
       - name: Show Xcode
         run: |
           xcodebuild -version

--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Dauphin is an iOS app with a companion Widget extension. The codebase is organiz
 2. Open `dauphin.xcodeproj` in Xcode.
 3. Select the `dauphin` scheme and build/run.
 
+### Xcode Cloud
+
+Define `AES256KEY` and `AES256IV` as secret custom environment variables in the workflow. The post-clone script generates the ignored `dauphin/api.plist` from `dauphin/api.example.plist` before Xcode builds the app.
+
 ## Common Commands
 
 ```sh

--- a/app/ci_scripts/ci_post_clone.sh
+++ b/app/ci_scripts/ci_post_clone.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+set -eu
+
+: "${AES256KEY:?Set AES256KEY in the Xcode Cloud workflow environment}"
+: "${AES256IV:?Set AES256IV in the Xcode Cloud workflow environment}"
+
+script_directory="$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)"
+template_path="${script_directory}/../dauphin/api.example.plist"
+output_path="${script_directory}/../dauphin/api.plist"
+temporary_path="$(mktemp "${output_path}.XXXXXX")"
+
+cleanup() {
+    rm -f "$temporary_path"
+}
+trap cleanup EXIT HUP INT TERM
+
+cp "$template_path" "$temporary_path"
+/usr/bin/plutil -replace AES.KEY -string "$AES256KEY" "$temporary_path"
+/usr/bin/plutil -replace AES.IV -string "$AES256IV" "$temporary_path"
+/usr/bin/plutil -lint "$temporary_path"
+mv "$temporary_path" "$output_path"
+trap - EXIT HUP INT TERM
+
+echo "Generated dauphin/api.plist for the Xcode Cloud build."

--- a/app/dauphin.xcodeproj/project.pbxproj
+++ b/app/dauphin.xcodeproj/project.pbxproj
@@ -832,7 +832,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				NEW_SETTING = "";
 				NEW_SETTING1 = "";
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.dev;
@@ -880,7 +880,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				NEW_SETTING = "";
 				NEW_SETTING1 = "";
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.dev;
@@ -913,7 +913,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.dev.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -946,7 +946,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.dev.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -980,7 +980,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.dev.StdID;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1013,7 +1013,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.dev.StdID;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1047,7 +1047,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1080,7 +1080,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1362,7 +1362,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				NEW_SETTING = "";
 				NEW_SETTING1 = "";
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin;
@@ -1409,7 +1409,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 15.1;
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				NEW_SETTING = "";
 				NEW_SETTING1 = "";
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin;
@@ -1442,7 +1442,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.StdID;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -1475,7 +1475,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 2.2.3;
+				MARKETING_VERSION = 2.2.4;
 				PRODUCT_BUNDLE_IDENTIFIER = club.ntut.tkuitocc.dauphin.StdID;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;

--- a/app/dauphin.xcodeproj/xcshareddata/xcodecloud/manifest.json
+++ b/app/dauphin.xcodeproj/xcshareddata/xcodecloud/manifest.json
@@ -1,0 +1,9 @@
+{
+  "id" : "b9af5189-0a46-47a5-8bf4-e95b36d3f4db",
+  "targets" : [
+    {
+      "id" : "b7847491-749a-4bb0-a129-e5ca79980bf4",
+      "name" : "dauphin"
+    }
+  ]
+}

--- a/app/dauphin/api.example.plist
+++ b/app/dauphin/api.example.plist
@@ -7,7 +7,7 @@
 		<key>IV</key>
 		<string>AES256IV</string>
 		<key>KEY</key>
-		<string>AES265KEY</string>
+		<string>AES256KEY</string>
 	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary

- generate the ignored `dauphin/api.plist` from its tracked example during Xcode Cloud's post-clone phase
- populate AES credentials from redacted `AES256KEY` and `AES256IV` workflow variables, failing safely when either is missing
- add the Xcode Cloud product manifest and document the required workflow configuration

## Testing

- [ ] Not run (explain why)
- [x] `xcodebuild -project app/dauphin.xcodeproj -scheme dauphin -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=27.0' test`
- [x] `xcrun swift-format lint --configuration app/.swift-format --recursive .` (completed with existing formatting warnings in files unaffected by this PR)
- [x] Post-clone script smoke test with representative and missing secrets
- [x] `xcodebuild -project app/dauphin.xcodeproj -scheme dauphin -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=27.0' build`

## Screenshots or Recordings (UI changes)

Not applicable.

## Related Issues

None.
